### PR TITLE
Get rid of Makefile, don't rebuild every time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,0 @@
-up: ## Stands up dev environment
-	docker-compose up --build
-
-down: ## Stops dev environment
-	docker-compose down

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You only need to have Docker installed.
 
 Bring the dev environment up with
 ```bash
-make up
+docker-compose up
 ```
 
 This will expose the Flask application's endpoints on port `5001`.
@@ -44,7 +44,7 @@ This will expose the Flask application's endpoints on port `5001`.
 To shut down:
 
 ```bash
-make down
+docker-compose down
 ```
 
 In order to make requests to private repositories, you will need to use your own Github personal access token.


### PR DESCRIPTION
When I first red the instructions, I thought there was a bit more going on in the `Makefile`, but since there isn't, I vote to remove it. People are more familiar with `docker-compose`, using `make` can be a handy shortcut but in this case entirely unneeded.

The second change here is `docker-compose up` is no longer called with `--build`, that forces it to always rebuild which can take time. Calling it without the switch will still build it the first time around, so it should work normally.

If the idea behind this was to simplify adding dependencies, I'd rather add another line to the readme and ask people to run `docker-compose build` if they add a dep and need to rebuild the container.