### PR TITLE
Remove the need for private repos and authorization

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,1 +1,0 @@
-GITHUB_API_TOKEN=your-personal-access-token-here

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ One of the basic integrations we have is integrating with various code source pr
 This task is designed so you get a feeling about what kind of problems you might be solving at Sleuth.
 
 In this task we ask you to design an API that will enable our users to:
-list **open** PRs of any Github repository (public and private). For each PR we want to display only the following information:
+list **open** PRs of any public Github repository. For each PR we want to display only the following information:
 
 - PR title
 - username of the PR author
@@ -15,13 +15,15 @@ list **open** PRs of any Github repository (public and private). For each PR we 
 - Head sha of the PR
 - Last time the PR was updated
 
+Return a JSON response, don't build any UI templates or frontend applications.
+
 ## Expectations
 
 - this task should take you around 30 minutes to solve
-- no UI, just an API that returns a JSON response
 - the response should respect `page` and `per_page` query parameters and indicate if all available PRs from Github are included in the response
 - no tests: definitely don't write any e2e or integration tests, but you are free to write unit tests if you feel like they will help you solve the task
 - we do not expect fully production ready code, but try to use best practices when designing large, scalable web applications as much as possible given the time restriction
+- no UI, just an API that returns a JSON response
 
 You are free to re-design and refactor everything (add additional dependencies, class and files names), but we expect to be able to run your solution as described below.
 If you are not comfortable using Python or this template, you are free to choose whichever language you are most comfortable with.
@@ -47,19 +49,10 @@ To shut down:
 docker-compose down
 ```
 
-In order to make requests to private repositories, you will need to use your own Github personal access token.
-You can create it [here](https://github.com/settings/tokens)
-Then add it to `.env` file
-```bash
-cp .env.template .env
-```
-and set `GITHUB_API_TOKEN` variable. You will need to rerun `make up` for the change to have effect.
-
-We suggest starting with using any public Github repository for testing. 
-
 ### Code structure
 
 This template provides a simple Flask API.
 
 - all the routes are defined in `api/app.py`, there you will find a couple demo endpoints and the one we expect you to implement
-- we have provided a simple `GithubREST` client in `api/github.py` that takes care of including the API token authorization header and provides a `get` method
+- we have provided a simple `GithubREST` client in `api/github.py` that provides a `get` method.
+- `query_params.py` includes a very simple parsing of request query parameters, that your API implementation needs to respect

--- a/api/app.py
+++ b/api/app.py
@@ -18,27 +18,26 @@ logging.basicConfig(
 )
 
 
-@app.route("/health")
-def health_check() -> Response:
-    return jsonify("OK")
+@app.route("/")
+def health_check() -> dict:
+    return {
+        "data": "Hello, welcome to Sleuth backend interview task. Please see instructions in README.md"
+    }
 
 
-@app.route("/github/whoami")
-def github_whoami():
-    logger.info("Github whoami called")
-    token = os.getenv("GITHUB_API_TOKEN")
-    if not token:
-        return {"error": "Github token not set"}
-
-    return GithubREST(token).get("/user")
+@app.route("/health/github")
+def github_whoami() -> dict:
+    return GithubREST().get("/")
 
 
-@app.route("/github/pulls/<path:repository>", methods=["GET"])
+@app.route("/github/repos/<path:repository>/pulls", methods=["GET"])
 def github_repository_pull_requests(repository: str):
     # collect query params
     page = request.args.get("page", DEFAULT_PAGE)
     per_page = request.args.get("per_page", DEFAULT_PER_PAGE)
     query_params = QueryParams(page=page, per_page=per_page)
+
+    # list repos PRs: https://docs.github.com/en/rest/pulls/pulls#list-pull-requests
 
     return {"data": f"TODO: got {repository=} and {query_params=}"}
 

--- a/api/github.py
+++ b/api/github.py
@@ -10,15 +10,6 @@ logger = logging.getLogger(__name__)
 class GithubREST:
     API_URL = "https://api.github.com"
 
-    def __init__(self, api_token: Optional[str] = None):
-        self.api_token = api_token
-
-    def _request_headers(self):
-        return {
-            "Accept": "application/vnd.github.moondragon+json",
-            "Authorization": f"Bearer {self.api_token}",
-        }
-
     def get(self, url_path: str, params: Optional[dict] = None) -> dict:
         """Call GitHub API. `url_path` should be with starting /."""
         if url_path and url_path.startswith("https://"):
@@ -30,7 +21,6 @@ class GithubREST:
         response = requests.get(
             full_url,
             params=params,
-            headers=self._request_headers(),
         )
         data = response.json()
         return {"links": response.links, "data": data}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
     environment:
       FLASK_DEBUG: "on"
       FLASK_APP: ./app.py
-      GITHUB_API_TOKEN: ${GITHUB_API_TOKEN}
     restart: always
     ports:
      - "5001:5001"


### PR DESCRIPTION
Add endpoint that listens on root, so candidates don't get confused.

Resolves #1 (token no longer needed) and #2 (root endpoint with reminder about instructions in readme)